### PR TITLE
Fixes #1

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 )
@@ -23,11 +24,41 @@ func main() {
 
 	for {
 		cmd := createCmd()
-		err := cmd.Start()
+		inpipe, err := cmd.StdinPipe()
+		if err != nil {
+			fmt.Printf("Failed to get program stdin: %v. Exiting.\n", err)
+			break
+		}
+		outpipe, err := cmd.StdoutPipe()
+		if err != nil {
+			fmt.Printf("Failed to get program stdout: %v. Exiting.\n", err)
+			break
+		}
+		errpipe, err := cmd.StderrPipe()
+		if err != nil {
+			fmt.Printf("Failed to get program stderr: %v. Exiting.\n", err)
+			break
+		}
+		err = cmd.Start()
 		if err != nil {
 			fmt.Printf("Failed to start program: %v. Exiting.\n", err)
 			break
 		}
+		//err,in and out are passed as parameter to avoid race conditions among
+		//different iterations of the loop
+		go func(inpipe io.WriteCloser) {
+			_, _ = io.Copy(inpipe, os.Stdin)
+			_ = inpipe.Close()
+		}(inpipe)
+		go func(outpipe io.ReadCloser) {
+			_, _ = io.Copy(os.Stdout, outpipe)
+			_ = outpipe.Close()
+		}(outpipe)
+		go func(errpipe io.ReadCloser) {
+			_, _ = io.Copy(os.Stderr, errpipe)
+			_ = errpipe.Close()
+		}(errpipe)
+
 		fmt.Printf("Successfully started program. Monitoring...\n")
 		err = cmd.Wait()
 		fmt.Printf("Program exited with error %v.\n", err)


### PR DESCRIPTION
Sample execution as a test:
### Command:
```
╰─$ while :
while> do
while> sleep 1
while> echo "foo"
while> done | ./keeprunning cat
```
While the command was running, I killed cat with `killall cat`

### Output
```
Successfully started program. Monitoring...
foo
foo
foo
foo
foo
foo
foo
Program exited with error signal: terminated.
Successfully started program. Monitoring...
foo
foo
foo
foo
foo
foo
```